### PR TITLE
Fix cancel functionality and session resume issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Claudia is a desktop application that provides a GUI wrapper and enhancement tool for Claude Code CLI. It's built with a hybrid architecture using React/TypeScript for the frontend and Rust/Tauri for the backend.
+
+## Essential Commands
+
+### Development
+```bash
+# Install dependencies
+bun install
+
+# Start development (hot reload for both frontend and backend)
+bun run tauri dev
+
+# Run frontend only (Vite dev server on port 1420)
+bun run dev
+
+# Type checking
+bunx tsc --noEmit
+```
+
+### Building
+```bash
+# Production build (creates platform-specific installers)
+bun run tauri build
+
+# Debug build
+bun run tauri build --debug
+
+# Build without bundling (just executable)
+bun run tauri build --no-bundle
+
+# macOS universal binary
+bun run tauri build --target universal-apple-darwin
+```
+
+### Testing & Code Quality
+```bash
+# Run Rust tests
+cd src-tauri && cargo test
+
+# Format Rust code
+cd src-tauri && cargo fmt
+```
+
+## Architecture
+
+### Technology Stack
+- **Frontend**: React 18 + TypeScript + Vite 6 + Tailwind CSS v4 + shadcn/ui
+- **Backend**: Rust with Tauri 2 framework
+- **Database**: SQLite (via rusqlite) for local data storage
+- **IPC**: Type-safe Tauri commands (176 registered commands)
+
+### Key Architectural Components
+
+1. **Security Sandboxing System** (`src-tauri/src/sandbox/`)
+   - OS-level sandboxing (seccomp on Linux, Seatbelt on macOS)
+   - Granular permission profiles for agent execution
+   - Violation tracking and audit logging
+
+2. **Agent Management** (`src-tauri/src/commands/agent.rs`)
+   - Custom AI agents with configurable system prompts
+   - Secure execution environment
+   - Real-time metrics and execution history
+
+3. **Checkpoint/Timeline System** (`src-tauri/src/checkpoint/`)
+   - Version control-like checkpointing for Claude sessions
+   - Branching and forking capabilities
+   - Diff viewing between checkpoints
+
+4. **MCP Integration** (`src-tauri/src/commands/mcp.rs`)
+   - Model Context Protocol server management
+   - Import/export capabilities
+   - Connection testing
+
+### Frontend Structure
+- `src/components/` - UI components organized by feature
+- `src/lib/` - Shared utilities and Tauri API client
+- Component state managed locally with React hooks
+- All backend communication through `src/lib/api.ts`
+
+### Backend Structure
+- `src-tauri/src/commands/` - Tauri IPC command handlers
+- `src-tauri/src/sandbox/` - Security sandboxing implementation
+- `src-tauri/src/checkpoint/` - Timeline/versioning management
+- `src-tauri/src/process/` - Process management utilities
+
+## Important Notes
+
+- The application requires Claude Code CLI to be installed and accessible
+- All Tauri commands are async and use the Tokio runtime
+- Frontend-backend communication is strictly through defined IPC commands
+- The sandbox system is critical for security - changes require thorough testing
+- Database operations use SQLite with rusqlite bindings

--- a/src-tauri/src/checkpoint/mod.rs
+++ b/src-tauri/src/checkpoint/mod.rs
@@ -243,14 +243,4 @@ impl CheckpointPaths {
     pub fn checkpoint_messages_file(&self, checkpoint_id: &str) -> PathBuf {
         self.checkpoint_dir(checkpoint_id).join("messages.jsonl")
     }
-    
-    pub fn file_snapshot_path(&self, _checkpoint_id: &str, file_hash: &str) -> PathBuf {
-        // In content-addressable storage, files are stored by hash in the content pool
-        self.files_dir.join("content_pool").join(file_hash)
-    }
-    
-    pub fn file_reference_path(&self, checkpoint_id: &str, safe_filename: &str) -> PathBuf {
-        // References are stored per checkpoint
-        self.files_dir.join("refs").join(checkpoint_id).join(format!("{}.json", safe_filename))
-    }
 } 

--- a/src-tauri/src/checkpoint/state.rs
+++ b/src-tauri/src/checkpoint/state.rs
@@ -84,13 +84,6 @@ impl CheckpointState {
         Ok(manager_arc)
     }
     
-    /// Gets an existing CheckpointManager for a session
-    /// 
-    /// Returns None if no manager exists for the session
-    pub async fn get_manager(&self, session_id: &str) -> Option<Arc<CheckpointManager>> {
-        let managers = self.managers.read().await;
-        managers.get(session_id).map(Arc::clone)
-    }
     
     /// Removes a CheckpointManager for a session
     /// 
@@ -100,13 +93,6 @@ impl CheckpointState {
         managers.remove(session_id)
     }
     
-    /// Clears all managers
-    /// 
-    /// This is useful for cleanup during application shutdown
-    pub async fn clear_all(&self) {
-        let mut managers = self.managers.write().await;
-        managers.clear();
-    }
     
     /// Gets the number of active managers
     pub async fn active_count(&self) -> usize {
@@ -120,17 +106,6 @@ impl CheckpointState {
         managers.keys().cloned().collect()
     }
     
-    /// Checks if a session has an active manager
-    pub async fn has_active_manager(&self, session_id: &str) -> bool {
-        self.get_manager(session_id).await.is_some()
-    }
-    
-    /// Clears all managers and returns the count that were cleared
-    pub async fn clear_all_and_count(&self) -> usize {
-        let count = self.active_count().await;
-        self.clear_all().await;
-        count
-    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -1,5 +1,4 @@
-use crate::sandbox::profile::{ProfileBuilder, SandboxRule};
-use crate::sandbox::executor::{SerializedProfile, SerializedOperation};
+use crate::sandbox::profile::ProfileBuilder;
 use anyhow::Result;
 use chrono;
 use log::{debug, error, info, warn};
@@ -8,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use tauri::{AppHandle, Manager, State, Emitter};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
-use log::{info, error, warn};
+use log::{info, error};
 use dirs;
 
 /// Helper function to create a std::process::Command with proper environment variables

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use commands::claude::{
     get_session_timeline, update_checkpoint_settings, get_checkpoint_diff,
     track_checkpoint_message, track_session_messages, check_auto_checkpoint, cleanup_old_checkpoints,
     get_checkpoint_settings, clear_checkpoint_manager, get_checkpoint_state_stats,
-    get_recently_modified_files,
+    get_recently_modified_files, cancel_claude_code, ClaudeProcessState,
 };
 use commands::agents::{
     init_database, list_agents, create_agent, update_agent, delete_agent, 
@@ -90,6 +90,9 @@ fn main() {
             // Initialize process registry
             app.manage(ProcessRegistryState::default());
             
+            // Initialize Claude process state
+            app.manage(ClaudeProcessState::default());
+            
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -125,6 +128,7 @@ fn main() {
             clear_checkpoint_manager,
             get_checkpoint_state_stats,
             get_recently_modified_files,
+            cancel_claude_code,
             list_agents,
             create_agent,
             update_agent,

--- a/src/components/FloatingPromptInput.tsx
+++ b/src/components/FloatingPromptInput.tsx
@@ -6,7 +6,8 @@ import {
   Minimize2,
   ChevronUp,
   Sparkles,
-  Zap
+  Zap,
+  X
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -42,6 +43,10 @@ interface FloatingPromptInputProps {
    * Optional className for styling
    */
   className?: string;
+  /**
+   * Optional callback to cancel current operation
+   */
+  onCancel?: () => void;
 }
 
 type Model = {
@@ -82,6 +87,7 @@ export const FloatingPromptInput: React.FC<FloatingPromptInputProps> = ({
   defaultModel = "sonnet",
   projectPath,
   className,
+  onCancel,
 }) => {
   const [prompt, setPrompt] = useState("");
   const [selectedModel, setSelectedModel] = useState<"sonnet" | "opus">(defaultModel);
@@ -540,25 +546,35 @@ export const FloatingPromptInput: React.FC<FloatingPromptInputProps> = ({
                 </AnimatePresence>
               </div>
               
-              {/* Send Button */}
-              <Button
-                onClick={handleSend}
-                disabled={!prompt.trim() || isLoading || disabled}
-                size="default"
-                className="min-w-[60px]"
-              >
-                {isLoading ? (
-                  <div className="rotating-symbol text-primary-foreground"></div>
-                ) : (
-                  <Send className="h-4 w-4" />
-                )}
-              </Button>
+              {/* Send/Cancel Button */}
+              {isLoading && onCancel ? (
+                <Button
+                  onClick={onCancel}
+                  variant="destructive"
+                  size="default"
+                  className="min-w-[60px]"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Button
+                  onClick={handleSend}
+                  disabled={!prompt.trim() || isLoading || disabled}
+                  size="default"
+                  className="min-w-[60px]"
+                >
+                  {isLoading ? (
+                    <div className="rotating-symbol text-primary-foreground"></div>
+                  ) : (
+                    <Send className="h-4 w-4" />
+                  )}
+                </Button>
+              )}
             </div>
             
             <div className="mt-2 text-xs text-muted-foreground">
               Press Enter to send, Shift+Enter for new line{projectPath?.trim() && ", @ to mention files, drag & drop images"}
             </div>
-          </div>
         </div>
       </div>
     </>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -919,6 +919,13 @@ export const api = {
   },
 
   /**
+   * Cancel the currently running Claude Code process
+   */
+  async cancelClaudeCode(): Promise<boolean> {
+    return invoke("cancel_claude_code", {});
+  },
+
+  /**
    * Lists files and directories in a given path
    */
   async listDirectoryContents(directoryPath: string): Promise<FileEntry[]> {


### PR DESCRIPTION
## Summary
- Fixed cancel button not working during Claude execution
- Added session validation to prevent "tool_use without tool_result" API errors
- Cleaned up unused code throughout the codebase

## Changes

### Cancel Functionality Fix
- Modified process handling to prevent the background task from removing the process prematurely
- Connected the `onCancel` prop to the `FloatingPromptInput` component
- Added `claude-cancelled` event listener in the frontend
- Cancel button now properly terminates the Claude process and updates the UI

### Session Resume Validation
- Added `validate_session_file` function to check for unpaired tool_use blocks before resuming
- When validation fails (corrupted session), the system falls back to starting a fresh conversation
- This prevents the API error: "tool_use ids were found without tool_result blocks"

### Code Cleanup
- Removed unused methods from `ProcessRegistry`
- Removed unused methods from `CheckpointPaths` and `CheckpointState`
- Fixed lifetime issues in async code for proper Send trait compliance
- Cleaned up unused imports using `cargo fix`

## Test Plan
- [x] Verify cancel button appears during Claude execution
- [x] Verify clicking cancel stops the Claude process
- [x] Verify sessions with unpaired tool_use blocks don't cause API errors
- [x] Run `cargo test` - all tests pass
- [x] Run `bunx tsc --noEmit` - no TypeScript errors