### PR TITLE
feat: Add Thai language font support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <title>Claudia - Claude Code Session Browser</title>
   </head>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,8 +35,8 @@
   --radius-xl: 1rem;
 
   /* Fonts */
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Noto Sans Thai", "TH Sarabun New", "Leelawadee UI", "Tahoma", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, "Noto Sans Mono", "TH Sarabun New", monospace;
 
   /* Transitions */
   --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
@@ -52,6 +52,21 @@ body {
   background-color: var(--color-background);
   color: var(--color-foreground);
   font-family: var(--font-sans);
+}
+
+/* Thai font support for all text elements */
+* {
+  font-family: var(--font-sans);
+}
+
+/* Ensure code elements use mono font with Thai support */
+code, pre, .font-mono {
+  font-family: var(--font-mono);
+}
+
+/* Specific Thai language support */
+:lang(th) {
+  font-family: "Noto Sans Thai", "TH Sarabun New", "Leelawadee UI", "Tahoma", sans-serif;
 }
 
 /* Placeholder text styling */


### PR DESCRIPTION
- Add Noto Sans Thai Google Font to index.html
- Update CSS font-family to include Thai fonts (Noto Sans Thai, TH Sarabun New, Leelawadee UI, Tahoma)
- Add specific Thai language CSS rules with :lang(th) selector
- Support Thai fonts for both sans-serif and monospace text

This change fixes the issue where Thai characters were displaying as squares (□) in the UI.