### PR TITLE
feat(ui): add new session button to SessionList with project path context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,384 +25,391 @@ type View = "welcome" | "projects" | "agents" | "editor" | "settings" | "claude-
  * Main App component - Manages the Claude directory browser UI
  */
 function App() {
-  const [view, setView] = useState<View>("welcome");
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [editingClaudeFile, setEditingClaudeFile] = useState<ClaudeMdFile | null>(null);
-  const [selectedSession, setSelectedSession] = useState<Session | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [showNFO, setShowNFO] = useState(false);
-  const [showClaudeBinaryDialog, setShowClaudeBinaryDialog] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "info" } | null>(null);
+    const [view, setView] = useState<View>("welcome");
+    const [projects, setProjects] = useState<Project[]>([]);
+    const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+    const [sessions, setSessions] = useState<Session[]>([]);
+    const [editingClaudeFile, setEditingClaudeFile] = useState<ClaudeMdFile | null>(null);
+    const [selectedSession, setSelectedSession] = useState<Session | null>(null);
+    const [newSessionProjectPath, setNewSessionProjectPath] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showNFO, setShowNFO] = useState(false);
+    const [showClaudeBinaryDialog, setShowClaudeBinaryDialog] = useState(false);
+    const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "info" } | null>(null);
 
-  // Load projects on mount when in projects view
-  useEffect(() => {
-    if (view === "projects") {
-      loadProjects();
-    } else if (view === "welcome") {
-      // Reset loading state for welcome view
-      setLoading(false);
-    }
-  }, [view]);
+    // Load projects on mount when in projects view
+    useEffect(() => {
+        if (view === "projects") {
+            loadProjects();
+        } else if (view === "welcome") {
+            // Reset loading state for welcome view
+            setLoading(false);
+        }
+    }, [view]);
 
-  // Listen for Claude session selection events
-  useEffect(() => {
-    const handleSessionSelected = (event: CustomEvent) => {
-      const { session } = event.detail;
-      setSelectedSession(session);
-      setView("claude-code-session");
+    // Listen for Claude session selection events
+    useEffect(() => {
+        const handleSessionSelected = (event: CustomEvent) => {
+            const { session } = event.detail;
+            setSelectedSession(session);
+            setView("claude-code-session");
+        };
+
+        const handleClaudeNotFound = () => {
+            setShowClaudeBinaryDialog(true);
+        };
+
+        window.addEventListener('claude-session-selected', handleSessionSelected as EventListener);
+        window.addEventListener('claude-not-found', handleClaudeNotFound as EventListener);
+        return () => {
+            window.removeEventListener('claude-session-selected', handleSessionSelected as EventListener);
+            window.removeEventListener('claude-not-found', handleClaudeNotFound as EventListener);
+        };
+    }, []);
+
+    /**
+     * Loads all projects from the ~/.claude/projects directory
+     */
+    const loadProjects = async () => {
+        try {
+            setLoading(true);
+            setError(null);
+            const projectList = await api.listProjects();
+            setProjects(projectList);
+        } catch (err) {
+            console.error("Failed to load projects:", err);
+            setError("Failed to load projects. Please ensure ~/.claude directory exists.");
+        } finally {
+            setLoading(false);
+        }
     };
 
-    const handleClaudeNotFound = () => {
-      setShowClaudeBinaryDialog(true);
+    /**
+     * Handles project selection and loads its sessions
+     */
+    const handleProjectClick = async (project: Project) => {
+        try {
+            setLoading(true);
+            setError(null);
+            const sessionList = await api.getProjectSessions(project.id);
+            setSessions(sessionList);
+            setSelectedProject(project);
+        } catch (err) {
+            console.error("Failed to load sessions:", err);
+            setError("Failed to load sessions for this project.");
+        } finally {
+            setLoading(false);
+        }
     };
 
-    window.addEventListener('claude-session-selected', handleSessionSelected as EventListener);
-    window.addEventListener('claude-not-found', handleClaudeNotFound as EventListener);
-    return () => {
-      window.removeEventListener('claude-session-selected', handleSessionSelected as EventListener);
-      window.removeEventListener('claude-not-found', handleClaudeNotFound as EventListener);
+    /**
+     * Opens a new Claude Code session in the interactive UI
+     */
+    const handleNewSession = async (projectPath?: string) => {
+        setView("claude-code-session");
+        setSelectedSession(null);
+        if (projectPath) {
+            setNewSessionProjectPath(projectPath || null);
+        }
     };
-  }, []);
 
-  /**
-   * Loads all projects from the ~/.claude/projects directory
-   */
-  const loadProjects = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const projectList = await api.listProjects();
-      setProjects(projectList);
-    } catch (err) {
-      console.error("Failed to load projects:", err);
-      setError("Failed to load projects. Please ensure ~/.claude directory exists.");
-    } finally {
-      setLoading(false);
-    }
-  };
+    /**
+     * Returns to project list view
+     */
+    const handleBack = () => {
+        setSelectedProject(null);
+        setSessions([]);
+    };
 
-  /**
-   * Handles project selection and loads its sessions
-   */
-  const handleProjectClick = async (project: Project) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const sessionList = await api.getProjectSessions(project.id);
-      setSessions(sessionList);
-      setSelectedProject(project);
-    } catch (err) {
-      console.error("Failed to load sessions:", err);
-      setError("Failed to load sessions for this project.");
-    } finally {
-      setLoading(false);
-    }
-  };
+    /**
+     * Handles editing a CLAUDE.md file from a project
+     */
+    const handleEditClaudeFile = (file: ClaudeMdFile) => {
+        setEditingClaudeFile(file);
+        setView("claude-file-editor");
+    };
 
-  /**
-   * Opens a new Claude Code session in the interactive UI
-   */
-  const handleNewSession = async () => {
-    setView("claude-code-session");
-    setSelectedSession(null);
-  };
+    /**
+     * Returns from CLAUDE.md file editor to projects view
+     */
+    const handleBackFromClaudeFileEditor = () => {
+        setEditingClaudeFile(null);
+        setView("projects");
+    };
 
-  /**
-   * Returns to project list view
-   */
-  const handleBack = () => {
-    setSelectedProject(null);
-    setSessions([]);
-  };
+    const renderContent = () => {
+        switch (view) {
+            case "welcome":
+                return (
+                    <div className="flex items-center justify-center p-4" style={{ height: "100%" }}>
+                        <div className="w-full max-w-4xl">
+                            {/* Welcome Header */}
+                            <motion.div
+                                initial={{ opacity: 0, y: -20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.5 }}
+                                className="mb-12 text-center"
+                            >
+                                <h1 className="text-4xl font-bold tracking-tight">
+                                    <span className="rotating-symbol"></span>
+                                    Welcome to Claudia
+                                </h1>
+                            </motion.div>
 
-  /**
-   * Handles editing a CLAUDE.md file from a project
-   */
-  const handleEditClaudeFile = (file: ClaudeMdFile) => {
-    setEditingClaudeFile(file);
-    setView("claude-file-editor");
-  };
+                            {/* Navigation Cards */}
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl mx-auto">
+                                {/* CC Agents Card */}
+                                <motion.div
+                                    initial={{ opacity: 0, scale: 0.9 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    transition={{ duration: 0.5, delay: 0.1 }}
+                                >
+                                    <Card
+                                        className="h-64 cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg border border-border/50 shimmer-hover"
+                                        onClick={() => setView("agents")}
+                                    >
+                                        <div className="h-full flex flex-col items-center justify-center p-8">
+                                            <Bot className="h-16 w-16 mb-4 text-primary" />
+                                            <h2 className="text-xl font-semibold">CC Agents</h2>
+                                        </div>
+                                    </Card>
+                                </motion.div>
 
-  /**
-   * Returns from CLAUDE.md file editor to projects view
-   */
-  const handleBackFromClaudeFileEditor = () => {
-    setEditingClaudeFile(null);
-    setView("projects");
-  };
+                                {/* CC Projects Card */}
+                                <motion.div
+                                    initial={{ opacity: 0, scale: 0.9 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    transition={{ duration: 0.5, delay: 0.2 }}
+                                >
+                                    <Card
+                                        className="h-64 cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg border border-border/50 shimmer-hover"
+                                        onClick={() => setView("projects")}
+                                    >
+                                        <div className="h-full flex flex-col items-center justify-center p-8">
+                                            <FolderCode className="h-16 w-16 mb-4 text-primary" />
+                                            <h2 className="text-xl font-semibold">CC Projects</h2>
+                                        </div>
+                                    </Card>
+                                </motion.div>
 
-  const renderContent = () => {
-    switch (view) {
-      case "welcome":
-        return (
-          <div className="flex items-center justify-center p-4" style={{ height: "100%" }}>
-            <div className="w-full max-w-4xl">
-              {/* Welcome Header */}
-              <motion.div
-                initial={{ opacity: 0, y: -20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-                className="mb-12 text-center"
-              >
-                <h1 className="text-4xl font-bold tracking-tight">
-                  <span className="rotating-symbol"></span>
-                  Welcome to Claudia
-                </h1>
-              </motion.div>
-
-              {/* Navigation Cards */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-2xl mx-auto">
-                {/* CC Agents Card */}
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.5, delay: 0.1 }}
-                >
-                  <Card 
-                    className="h-64 cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg border border-border/50 shimmer-hover"
-                    onClick={() => setView("agents")}
-                  >
-                    <div className="h-full flex flex-col items-center justify-center p-8">
-                      <Bot className="h-16 w-16 mb-4 text-primary" />
-                      <h2 className="text-xl font-semibold">CC Agents</h2>
-                    </div>
-                  </Card>
-                </motion.div>
-
-                {/* CC Projects Card */}
-                <motion.div
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.5, delay: 0.2 }}
-                >
-                  <Card 
-                    className="h-64 cursor-pointer transition-all duration-200 hover:scale-105 hover:shadow-lg border border-border/50 shimmer-hover"
-                    onClick={() => setView("projects")}
-                  >
-                    <div className="h-full flex flex-col items-center justify-center p-8">
-                      <FolderCode className="h-16 w-16 mb-4 text-primary" />
-                      <h2 className="text-xl font-semibold">CC Projects</h2>
-                    </div>
-                  </Card>
-                </motion.div>
-
-              </div>
-            </div>
-          </div>
-        );
-
-      case "agents":
-        return (
-          <div className="flex-1 overflow-hidden">
-            <CCAgents onBack={() => setView("welcome")} />
-          </div>
-        );
-
-      case "editor":
-        return (
-          <div className="flex-1 overflow-hidden">
-            <MarkdownEditor onBack={() => setView("welcome")} />
-          </div>
-        );
-      
-      case "settings":
-        return (
-          <div className="flex-1 flex flex-col" style={{ minHeight: 0 }}>
-            <Settings onBack={() => setView("welcome")} />
-          </div>
-        );
-      
-      case "projects":
-        return (
-          <div className="flex h-full items-center justify-center p-4 overflow-y-auto">
-            <div className="w-full max-w-2xl">
-              {/* Header with back button */}
-              <motion.div
-                initial={{ opacity: 0, y: -20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-                className="mb-6"
-              >
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setView("welcome")}
-                  className="mb-4"
-                >
-                  ← Back to Home
-                </Button>
-                <div className="text-center">
-                  <h1 className="text-3xl font-bold tracking-tight">CC Projects</h1>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Browse your Claude Code sessions
-                  </p>
-                </div>
-              </motion.div>
-
-              {/* Error display */}
-              {error && (
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="mb-4 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-xs text-destructive"
-                >
-                  {error}
-                </motion.div>
-              )}
-
-              {/* Loading state */}
-              {loading && (
-                <div className="flex items-center justify-center py-8">
-                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-                </div>
-              )}
-
-              {/* Content */}
-              {!loading && (
-                <AnimatePresence mode="wait">
-                  {selectedProject ? (
-                    <motion.div
-                      key="sessions"
-                      initial={{ opacity: 0, x: 20 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: -20 }}
-                      transition={{ duration: 0.3 }}
-                    >
-                      <SessionList
-                        sessions={sessions}
-                        projectPath={selectedProject.path}
-                        onBack={handleBack}
-                        onEditClaudeFile={handleEditClaudeFile}
-                      />
-                    </motion.div>
-                  ) : (
-                    <motion.div
-                      key="projects"
-                      initial={{ opacity: 0, x: -20 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: 20 }}
-                      transition={{ duration: 0.3 }}
-                      className="space-y-4"
-                    >
-                      {/* New session button at the top */}
-                      <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.5 }}
-                      >
-                        <Button
-                          onClick={handleNewSession}
-                          size="default"
-                          className="w-full"
-                        >
-                          <Plus className="mr-2 h-4 w-4" />
-                          New Claude Code session
-                        </Button>
-                      </motion.div>
-
-                      {/* Project list */}
-                      {projects.length > 0 ? (
-                        <ProjectList
-                          projects={projects}
-                          onProjectClick={handleProjectClick}
-                        />
-                      ) : (
-                        <div className="py-8 text-center">
-                          <p className="text-sm text-muted-foreground">
-                            No projects found in ~/.claude/projects
-                          </p>
+                            </div>
                         </div>
-                      )}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              )}
-            </div>
-          </div>
-        );
-      
-      case "claude-file-editor":
-        return editingClaudeFile ? (
-          <ClaudeFileEditor
-            file={editingClaudeFile}
-            onBack={handleBackFromClaudeFileEditor}
-          />
-        ) : null;
-      
-      case "claude-code-session":
-        return (
-          <ClaudeCodeSession
-            session={selectedSession || undefined}
-            onBack={() => {
-              setSelectedSession(null);
-              setView("projects");
-            }}
-          />
-        );
-      
-      case "usage-dashboard":
-        return (
-          <UsageDashboard onBack={() => setView("welcome")} />
-        );
-      
-      case "mcp":
-        return (
-          <MCPManager onBack={() => setView("welcome")} />
-        );
-      
-      default:
-        return null;
-    }
-  };
+                    </div>
+                );
 
-  return (
-    <OutputCacheProvider>
-      <div className="h-screen bg-background flex flex-col">
-        {/* Topbar */}
-        <Topbar
-          onClaudeClick={() => setView("editor")}
-          onSettingsClick={() => setView("settings")}
-          onUsageClick={() => setView("usage-dashboard")}
-          onMCPClick={() => setView("mcp")}
-          onInfoClick={() => setShowNFO(true)}
-        />
-        
-        {/* Main Content */}
-        <div className="flex-1 overflow-y-auto">
-          {renderContent()}
-        </div>
-        
-        {/* NFO Credits Modal */}
-        {showNFO && <NFOCredits onClose={() => setShowNFO(false)} />}
-        
-        {/* Claude Binary Dialog */}
-        <ClaudeBinaryDialog
-          open={showClaudeBinaryDialog}
-          onOpenChange={setShowClaudeBinaryDialog}
-          onSuccess={() => {
-            setToast({ message: "Claude binary path saved successfully", type: "success" });
-            // Trigger a refresh of the Claude version check
-            window.location.reload();
-          }}
-          onError={(message) => setToast({ message, type: "error" })}
-        />
-        
-        {/* Toast Container */}
-        <ToastContainer>
-          {toast && (
-            <Toast
-              message={toast.message}
-              type={toast.type}
-              onDismiss={() => setToast(null)}
-            />
-          )}
-        </ToastContainer>
-      </div>
-    </OutputCacheProvider>
-  );
+            case "agents":
+                return (
+                    <div className="flex-1 overflow-hidden">
+                        <CCAgents onBack={() => setView("welcome")} />
+                    </div>
+                );
+
+            case "editor":
+                return (
+                    <div className="flex-1 overflow-hidden">
+                        <MarkdownEditor onBack={() => setView("welcome")} />
+                    </div>
+                );
+
+            case "settings":
+                return (
+                    <div className="flex-1 flex flex-col" style={{ minHeight: 0 }}>
+                        <Settings onBack={() => setView("welcome")} />
+                    </div>
+                );
+
+            case "projects":
+                return (
+                    <div className="flex h-full items-center justify-center p-4 overflow-y-auto">
+                        <div className="w-full max-w-2xl">
+                            {/* Header with back button */}
+                            <motion.div
+                                initial={{ opacity: 0, y: -20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.5 }}
+                                className="mb-6"
+                            >
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setView("welcome")}
+                                    className="mb-4"
+                                >
+                                    ← Back to Home
+                                </Button>
+                                <div className="text-center">
+                                    <h1 className="text-3xl font-bold tracking-tight">CC Projects</h1>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                        Browse your Claude Code sessions
+                                    </p>
+                                </div>
+                            </motion.div>
+
+                            {/* Error display */}
+                            {error && (
+                                <motion.div
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    className="mb-4 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-xs text-destructive"
+                                >
+                                    {error}
+                                </motion.div>
+                            )}
+
+                            {/* Loading state */}
+                            {loading && (
+                                <div className="flex items-center justify-center py-8">
+                                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                                </div>
+                            )}
+
+                            {/* Content */}
+                            {!loading && (
+                                <AnimatePresence mode="wait">
+                                    {selectedProject ? (
+                                        <motion.div
+                                            key="sessions"
+                                            initial={{ opacity: 0, x: 20 }}
+                                            animate={{ opacity: 1, x: 0 }}
+                                            exit={{ opacity: 0, x: -20 }}
+                                            transition={{ duration: 0.3 }}
+                                        >
+                                            <SessionList
+                                                sessions={sessions}
+                                                projectPath={selectedProject.path}
+                                                onBack={handleBack}
+                                                onEditClaudeFile={handleEditClaudeFile}
+                                                onCreateSession={handleNewSession}
+                                            />
+                                        </motion.div>
+                                    ) : (
+                                        <motion.div
+                                            key="projects"
+                                            initial={{ opacity: 0, x: -20 }}
+                                            animate={{ opacity: 1, x: 0 }}
+                                            exit={{ opacity: 0, x: 20 }}
+                                            transition={{ duration: 0.3 }}
+                                            className="space-y-4"
+                                        >
+                                            {/* New session button at the top */}
+                                            <motion.div
+                                                initial={{ opacity: 0, y: 20 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                transition={{ duration: 0.5 }}
+                                            >
+                                                <Button
+                                                    onClick={() => handleNewSession()}
+                                                    size="default"
+                                                    className="w-full"
+                                                >
+                                                    <Plus className="mr-2 h-4 w-4" />
+                                                    New Claude Code session
+                                                </Button>
+                                            </motion.div>
+
+                                            {/* Project list */}
+                                            {projects.length > 0 ? (
+                                                <ProjectList
+                                                    projects={projects}
+                                                    onProjectClick={handleProjectClick}
+                                                />
+                                            ) : (
+                                                <div className="py-8 text-center">
+                                                    <p className="text-sm text-muted-foreground">
+                                                        No projects found in ~/.claude/projects
+                                                    </p>
+                                                </div>
+                                            )}
+                                        </motion.div>
+                                    )}
+                                </AnimatePresence>
+                            )}
+                        </div>
+                    </div>
+                );
+
+            case "claude-file-editor":
+                return editingClaudeFile ? (
+                    <ClaudeFileEditor
+                        file={editingClaudeFile}
+                        onBack={handleBackFromClaudeFileEditor}
+                    />
+                ) : null;
+
+            case "claude-code-session":
+                return (
+                    <ClaudeCodeSession
+                        session={selectedSession || undefined}
+                        initialProjectPath={newSessionProjectPath || undefined}
+                        onBack={() => {
+                            setSelectedSession(null);
+                            setNewSessionProjectPath(null);
+                            setView("projects");
+                        }}
+                    />
+                );
+
+            case "usage-dashboard":
+                return (
+                    <UsageDashboard onBack={() => setView("welcome")} />
+                );
+
+            case "mcp":
+                return (
+                    <MCPManager onBack={() => setView("welcome")} />
+                );
+
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <OutputCacheProvider>
+            <div className="h-screen bg-background flex flex-col">
+                {/* Topbar */}
+                <Topbar
+                    onClaudeClick={() => setView("editor")}
+                    onSettingsClick={() => setView("settings")}
+                    onUsageClick={() => setView("usage-dashboard")}
+                    onMCPClick={() => setView("mcp")}
+                    onInfoClick={() => setShowNFO(true)}
+                />
+
+                {/* Main Content */}
+                <div className="flex-1 overflow-y-auto">
+                    {renderContent()}
+                </div>
+
+                {/* NFO Credits Modal */}
+                {showNFO && <NFOCredits onClose={() => setShowNFO(false)} />}
+
+                {/* Claude Binary Dialog */}
+                <ClaudeBinaryDialog
+                    open={showClaudeBinaryDialog}
+                    onOpenChange={setShowClaudeBinaryDialog}
+                    onSuccess={() => {
+                        setToast({ message: "Claude binary path saved successfully", type: "success" });
+                        // Trigger a refresh of the Claude version check
+                        window.location.reload();
+                    }}
+                    onError={(message) => setToast({ message, type: "error" })}
+                />
+
+                {/* Toast Container */}
+                <ToastContainer>
+                    {toast && (
+                        <Toast
+                            message={toast.message}
+                            type={toast.type}
+                            onDismiss={() => setToast(null)}
+                        />
+                    )}
+                </ToastContainer>
+            </div>
+        </OutputCacheProvider>
+    );
 }
 
 export default App;

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { FileText, ArrowLeft, Calendar, Clock, MessageSquare } from "lucide-react";
+import { FileText, ArrowLeft, Calendar, Clock, MessageSquare, Plus } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Pagination } from "@/components/ui/pagination";
@@ -10,30 +10,34 @@ import { formatUnixTimestamp, formatISOTimestamp, truncateText, getFirstLine } f
 import type { Session, ClaudeMdFile } from "@/lib/api";
 
 interface SessionListProps {
-  /**
-   * Array of sessions to display
-   */
-  sessions: Session[];
-  /**
-   * The current project path being viewed
-   */
-  projectPath: string;
-  /**
-   * Callback to go back to project list
-   */
-  onBack: () => void;
-  /**
-   * Callback when a session is clicked
-   */
-  onSessionClick?: (session: Session) => void;
-  /**
-   * Callback when a CLAUDE.md file should be edited
-   */
-  onEditClaudeFile?: (file: ClaudeMdFile) => void;
-  /**
-   * Optional className for styling
-   */
-  className?: string;
+    /**
+     * Array of sessions to display
+     */
+    sessions: Session[];
+    /**
+     * The current project path being viewed
+     */
+    projectPath: string;
+    /**
+     * Callback to go back to project list
+     */
+    onBack: () => void;
+    /**
+     * Callback to create a new session
+     */
+    onCreateSession?: (projectPath: string) => void;
+    /**
+     * Callback when a session is clicked
+     */
+    onSessionClick?: (session: Session) => void;
+    /**
+     * Callback when a CLAUDE.md file should be edited
+     */
+    onEditClaudeFile?: (file: ClaudeMdFile) => void;
+    /**
+     * Optional className for styling
+     */
+    className?: string;
 }
 
 const ITEMS_PER_PAGE = 5;
@@ -50,149 +54,161 @@ const ITEMS_PER_PAGE = 5;
  * />
  */
 export const SessionList: React.FC<SessionListProps> = ({
-  sessions,
-  projectPath,
-  onBack,
-  onSessionClick,
-  onEditClaudeFile,
-  className,
+    sessions,
+    projectPath,
+    onBack,
+    onCreateSession,
+    onSessionClick,
+    onEditClaudeFile,
+    className,
 }) => {
-  const [currentPage, setCurrentPage] = useState(1);
-  
-  // Calculate pagination
-  const totalPages = Math.ceil(sessions.length / ITEMS_PER_PAGE);
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-  const endIndex = startIndex + ITEMS_PER_PAGE;
-  const currentSessions = sessions.slice(startIndex, endIndex);
-  
-  // Reset to page 1 if sessions change
-  React.useEffect(() => {
-    setCurrentPage(1);
-  }, [sessions.length]);
-  
-  return (
-    <div className={cn("space-y-4", className)}>
-      <motion.div
-        initial={{ opacity: 0, x: -20 }}
-        animate={{ opacity: 1, x: 0 }}
-        transition={{ duration: 0.3 }}
-        className="flex items-center space-x-3"
-      >
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onBack}
-          className="h-8 w-8"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Button>
-        <div className="flex-1 min-w-0">
-          <h2 className="text-base font-medium truncate">{projectPath}</h2>
-          <p className="text-xs text-muted-foreground">
-            {sessions.length} session{sessions.length !== 1 ? 's' : ''}
-          </p>
-        </div>
-      </motion.div>
+    const [currentPage, setCurrentPage] = useState(1);
 
-      {/* CLAUDE.md Memories Dropdown */}
-      {onEditClaudeFile && (
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.3, delay: 0.1 }}
-        >
-          <ClaudeMemoriesDropdown
-            projectPath={projectPath}
-            onEditFile={onEditClaudeFile}
-          />
-        </motion.div>
-      )}
+    // Calculate pagination
+    const totalPages = Math.ceil(sessions.length / ITEMS_PER_PAGE);
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    const currentSessions = sessions.slice(startIndex, endIndex);
 
-      <AnimatePresence mode="popLayout">
-        <div className="space-y-2">
-          {currentSessions.map((session, index) => (
+    // Reset to page 1 if sessions change
+    React.useEffect(() => {
+        setCurrentPage(1);
+    }, [sessions.length]);
+
+    return (
+        <div className={cn("space-y-4", className)}>
             <motion.div
-              key={session.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -20 }}
-              transition={{
-                duration: 0.3,
-                delay: index * 0.05,
-                ease: [0.4, 0, 0.2, 1],
-              }}
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ duration: 0.3 }}
+                className="flex items-center space-x-3"
             >
-              <Card
-                className={cn(
-                  "transition-all hover:shadow-md hover:scale-[1.01] active:scale-[0.99] cursor-pointer",
-                  session.todo_data && "border-l-4 border-l-primary"
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onBack}
+                    className="h-8 w-8"
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                </Button>
+                <div className="flex-1 min-w-0">
+                    <h2 className="text-base font-medium truncate">{projectPath}</h2>
+                    <p className="text-xs text-muted-foreground">
+                        {sessions.length} session{sessions.length !== 1 ? 's' : ''}
+                    </p>
+                </div>
+                {onCreateSession && (
+                    <Button
+                        variant="default"
+                        size="sm"
+                        onClick={() => onCreateSession(projectPath)}
+                        className="flex items-center space-x-2"
+                    >
+                        <Plus className="h-4 w-4" />
+                        <span>New Session</span>
+                    </Button>
                 )}
-                onClick={() => {
-                  // Emit a special event for Claude Code session navigation
-                  const event = new CustomEvent('claude-session-selected', { 
-                    detail: { session, projectPath } 
-                  });
-                  window.dispatchEvent(event);
-                  onSessionClick?.(session);
-                }}
-              >
-                <CardContent className="p-3">
-                  <div className="space-y-2">
-                    <div className="flex items-start justify-between">
-                      <div className="flex items-start space-x-3 flex-1 min-w-0">
-                        <FileText className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
-                        <div className="space-y-1 flex-1 min-w-0">
-                          <p className="font-mono text-xs text-muted-foreground">{session.id}</p>
-                          
-                          {/* First message preview */}
-                          {session.first_message && (
-                            <div className="space-y-1">
-                              <div className="flex items-center space-x-1 text-xs text-muted-foreground">
-                                <MessageSquare className="h-3 w-3" />
-                                <span>First message:</span>
-                              </div>
-                              <p className="text-xs line-clamp-2 text-foreground/80">
-                                {truncateText(getFirstLine(session.first_message), 100)}
-                              </p>
-                            </div>
-                          )}
-                          
-                          {/* Metadata */}
-                          <div className="flex items-center space-x-3 text-xs text-muted-foreground">
-                            {/* Message timestamp if available, otherwise file creation time */}
-                            <div className="flex items-center space-x-1">
-                              <Clock className="h-3 w-3" />
-                              <span>
-                                {session.message_timestamp 
-                                  ? formatISOTimestamp(session.message_timestamp)
-                                  : formatUnixTimestamp(session.created_at)
-                                }
-                              </span>
-                            </div>
-                            
-                            {session.todo_data && (
-                              <div className="flex items-center space-x-1">
-                                <Calendar className="h-3 w-3" />
-                                <span>Has todo</span>
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
             </motion.div>
-          ))}
+
+            {/* CLAUDE.md Memories Dropdown */}
+            {onEditClaudeFile && (
+                <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3, delay: 0.1 }}
+                >
+                    <ClaudeMemoriesDropdown
+                        projectPath={projectPath}
+                        onEditFile={onEditClaudeFile}
+                    />
+                </motion.div>
+            )}
+
+            <AnimatePresence mode="popLayout">
+                <div className="space-y-2">
+                    {currentSessions.map((session, index) => (
+                        <motion.div
+                            key={session.id}
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -20 }}
+                            transition={{
+                                duration: 0.3,
+                                delay: index * 0.05,
+                                ease: [0.4, 0, 0.2, 1],
+                            }}
+                        >
+                            <Card
+                                className={cn(
+                                    "transition-all hover:shadow-md hover:scale-[1.01] active:scale-[0.99] cursor-pointer",
+                                    session.todo_data && "border-l-4 border-l-primary"
+                                )}
+                                onClick={() => {
+                                    // Emit a special event for Claude Code session navigation
+                                    const event = new CustomEvent('claude-session-selected', {
+                                        detail: { session, projectPath }
+                                    });
+                                    window.dispatchEvent(event);
+                                    onSessionClick?.(session);
+                                }}
+                            >
+                                <CardContent className="p-3">
+                                    <div className="space-y-2">
+                                        <div className="flex items-start justify-between">
+                                            <div className="flex items-start space-x-3 flex-1 min-w-0">
+                                                <FileText className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+                                                <div className="space-y-1 flex-1 min-w-0">
+                                                    <p className="font-mono text-xs text-muted-foreground">{session.id}</p>
+
+                                                    {/* First message preview */}
+                                                    {session.first_message && (
+                                                        <div className="space-y-1">
+                                                            <div className="flex items-center space-x-1 text-xs text-muted-foreground">
+                                                                <MessageSquare className="h-3 w-3" />
+                                                                <span>First message:</span>
+                                                            </div>
+                                                            <p className="text-xs line-clamp-2 text-foreground/80">
+                                                                {truncateText(getFirstLine(session.first_message), 100)}
+                                                            </p>
+                                                        </div>
+                                                    )}
+
+                                                    {/* Metadata */}
+                                                    <div className="flex items-center space-x-3 text-xs text-muted-foreground">
+                                                        {/* Message timestamp if available, otherwise file creation time */}
+                                                        <div className="flex items-center space-x-1">
+                                                            <Clock className="h-3 w-3" />
+                                                            <span>
+                                                                {session.message_timestamp
+                                                                    ? formatISOTimestamp(session.message_timestamp)
+                                                                    : formatUnixTimestamp(session.created_at)
+                                                                }
+                                                            </span>
+                                                        </div>
+
+                                                        {session.todo_data && (
+                                                            <div className="flex items-center space-x-1">
+                                                                <Calendar className="h-3 w-3" />
+                                                                <span>Has todo</span>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        </motion.div>
+                    ))}
+                </div>
+            </AnimatePresence>
+
+            <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={setCurrentPage}
+            />
         </div>
-      </AnimatePresence>
-      
-      <Pagination
-        currentPage={currentPage}
-        totalPages={totalPages}
-        onPageChange={setCurrentPage}
-      />
-    </div>
-  );
+    );
 }; 


### PR DESCRIPTION
## Summary
- Add "New Session" button to SessionList component that automatically passes the current project path
- Update SessionList interface to accept onCreateSession callback with projectPath parameter  
- Modify App.tsx to handle new session creation with pre-populated project path
- Enhance UX by eliminating the need to manually select project path when creating sessions from project view

## Changes Made
- **SessionList.tsx**: Added Plus icon import, onCreateSession prop, and New Session button
- **App.tsx**: Added newSessionProjectPath state, updated handleNewSession to accept projectPath parameter, and passed initialProjectPath to ClaudeCodeSession

## Test Plan
- [x] Verify New Session button appears in SessionList
- [x] Verify clicking button creates new session with correct project path
- [x] Verify project path is automatically filled in ClaudeCodeSession
- [x] Verify existing functionality (session navigation, back button) still works

🤖 Generated with [Claude Code](https://claude.ai/code)