### PR TITLE
feat: add theme selector with light/dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en" class="light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/components/ClaudeFileEditor.tsx
+++ b/src/components/ClaudeFileEditor.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { ArrowLeft, Save, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Toast, ToastContainer } from "@/components/ui/toast";
+import { useTheme } from "@/contexts/ThemeContext";
 import { api, type ClaudeMdFile } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -36,6 +37,7 @@ export const ClaudeFileEditor: React.FC<ClaudeFileEditorProps> = ({
   onBack,
   className,
 }) => {
+  const { theme } = useTheme();
   const [content, setContent] = useState<string>("");
   const [originalContent, setOriginalContent] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -151,7 +153,7 @@ export const ClaudeFileEditor: React.FC<ClaudeFileEditorProps> = ({
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <div className="h-full rounded-lg border border-border overflow-hidden shadow-sm" data-color-mode="dark">
+            <div className="h-full rounded-lg border border-border overflow-hidden shadow-sm" data-color-mode={theme}>
               <MDEditor
                 value={content}
                 onChange={(val) => setContent(val || "")}

--- a/src/components/CreateAgent.tsx
+++ b/src/components/CreateAgent.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Toast, ToastContainer } from "@/components/ui/toast";
+import { useTheme } from "@/contexts/ThemeContext";
 import { api, type Agent } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import MDEditor from "@uiw/react-md-editor";
@@ -43,6 +44,7 @@ export const CreateAgent: React.FC<CreateAgentProps> = ({
   onAgentCreated,
   className,
 }) => {
+  const { theme } = useTheme();
   const [name, setName] = useState(agent?.name || "");
   const [selectedIcon, setSelectedIcon] = useState<AgentIconName>((agent?.icon as AgentIconName) || "bot");
   const [systemPrompt, setSystemPrompt] = useState(agent?.system_prompt || "");
@@ -339,7 +341,7 @@ export const CreateAgent: React.FC<CreateAgentProps> = ({
                 <p className="text-xs text-muted-foreground mb-2">
                   Define the behavior and capabilities of your CC Agent
                 </p>
-                <div className="rounded-lg border border-border overflow-hidden shadow-sm" data-color-mode="dark">
+                <div className="rounded-lg border border-border overflow-hidden shadow-sm" data-color-mode={theme}>
                   <MDEditor
                     value={systemPrompt}
                     onChange={(val) => setSystemPrompt(val || "")}

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { ArrowLeft, Save, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Toast, ToastContainer } from "@/components/ui/toast";
+import { useTheme } from "@/contexts/ThemeContext";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -28,6 +29,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   onBack,
   className,
 }) => {
+  const { theme } = useTheme();
   const [content, setContent] = useState<string>("");
   const [originalContent, setOriginalContent] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -143,7 +145,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <div className="h-full rounded-lg border border-border overflow-hidden shadow-sm" data-color-mode="dark">
+            <div className="h-full rounded-lg border border-border overflow-hidden shadow-sm" data-color-mode={theme}>
               <MDEditor
                 value={content}
                 onChange={(val) => setContent(val || "")}

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useTheme } from '@/contexts/ThemeContext';
+import { cn } from '@/lib/utils';
+
+interface ThemeSelectorProps {
+  className?: string;
+}
+
+export const ThemeSelector: React.FC<ThemeSelectorProps> = ({ className }) => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      className={cn("h-8 w-8", className)}
+      title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? (
+        <Moon className="h-4 w-4" />
+      ) : (
+        <Sun className="h-4 w-4" />
+      )}
+    </Button>
+  );
+};

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Circle, FileText, Settings, ExternalLink, BarChart3, Network, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover } from "@/components/ui/popover";
+import { ThemeSelector } from "@/components/ThemeSelector";
 import { api, type ClaudeVersionStatus } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -222,6 +223,8 @@ export const Topbar: React.FC<TopbarProps> = ({
         >
           <Info className="h-4 w-4" />
         </Button>
+        
+        <ThemeSelector />
       </div>
     </motion.div>
   );

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    // Check localStorage first, then system preference
+    const saved = localStorage.getItem('theme') as Theme;
+    if (saved) return saved;
+    
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  const setTheme = (newTheme: Theme) => {
+    setThemeState(newTheme);
+    localStorage.setItem('theme', newTheme);
+    
+    // Update HTML class
+    document.documentElement.className = newTheme;
+  };
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
+  // Initialize theme on mount
+  useEffect(() => {
+    document.documentElement.className = theme;
+  }, []);
+
+  // Listen for system theme changes
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    
+    const handleChange = (e: MediaQueryListEvent) => {
+      // Only update if no theme is saved in localStorage
+      if (!localStorage.getItem('theme')) {
+        setTheme(e.matches ? 'dark' : 'light');
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/lib/claudeSyntaxTheme.ts
+++ b/src/lib/claudeSyntaxTheme.ts
@@ -1,175 +1,162 @@
 /**
  * Claude-themed syntax highlighting theme
  * Features orange, purple, and violet colors to match Claude's aesthetic
+ * Supports both light and dark themes
  */
-export const claudeSyntaxTheme: any = {
-  'code[class*="language-"]': {
-    color: '#e3e8f0',
-    background: 'transparent',
-    textShadow: 'none',
-    fontFamily: 'var(--font-mono)',
-    fontSize: '0.875em',
-    textAlign: 'left',
-    whiteSpace: 'pre',
-    wordSpacing: 'normal',
-    wordBreak: 'normal',
-    wordWrap: 'normal',
-    lineHeight: '1.5',
-    MozTabSize: '4',
-    OTabSize: '4',
-    tabSize: '4',
-    WebkitHyphens: 'none',
-    MozHyphens: 'none',
-    msHyphens: 'none',
-    hyphens: 'none',
-  },
-  'pre[class*="language-"]': {
-    color: '#e3e8f0',
-    background: 'transparent',
-    textShadow: 'none',
-    fontFamily: 'var(--font-mono)',
-    fontSize: '0.875em',
-    textAlign: 'left',
-    whiteSpace: 'pre',
-    wordSpacing: 'normal',
-    wordBreak: 'normal',
-    wordWrap: 'normal',
-    lineHeight: '1.5',
-    MozTabSize: '4',
-    OTabSize: '4',
-    tabSize: '4',
-    WebkitHyphens: 'none',
-    MozHyphens: 'none',
-    msHyphens: 'none',
-    hyphens: 'none',
-    padding: '1em',
-    margin: '0',
-    overflow: 'auto',
-  },
-  ':not(pre) > code[class*="language-"]': {
-    background: 'rgba(139, 92, 246, 0.1)',
-    padding: '0.1em 0.3em',
-    borderRadius: '0.3em',
-    whiteSpace: 'normal',
-  },
-  'comment': {
-    color: '#6b7280',
-    fontStyle: 'italic',
-  },
-  'prolog': {
-    color: '#6b7280',
-  },
-  'doctype': {
-    color: '#6b7280',
-  },
-  'cdata': {
-    color: '#6b7280',
-  },
-  'punctuation': {
-    color: '#9ca3af',
-  },
-  'namespace': {
-    opacity: '0.7',
-  },
-  'property': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'tag': {
-    color: '#8b5cf6', // Violet
-  },
-  'boolean': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'number': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'constant': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'symbol': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'deleted': {
-    color: '#ef4444',
-  },
-  'selector': {
-    color: '#a78bfa', // Light Purple
-  },
-  'attr-name': {
-    color: '#a78bfa', // Light Purple
-  },
-  'string': {
-    color: '#10b981', // Emerald Green
-  },
-  'char': {
-    color: '#10b981', // Emerald Green
-  },
-  'builtin': {
-    color: '#8b5cf6', // Violet
-  },
-  'url': {
-    color: '#10b981', // Emerald Green
-  },
-  'inserted': {
-    color: '#10b981', // Emerald Green
-  },
-  'entity': {
-    color: '#a78bfa', // Light Purple
-    cursor: 'help',
-  },
-  'atrule': {
-    color: '#c084fc', // Light Violet
-  },
-  'attr-value': {
-    color: '#10b981', // Emerald Green
-  },
-  'keyword': {
-    color: '#c084fc', // Light Violet
-  },
-  'function': {
-    color: '#818cf8', // Indigo
-  },
-  'class-name': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'regex': {
-    color: '#06b6d4', // Cyan
-  },
-  'important': {
-    color: '#f59e0b', // Amber/Orange
-    fontWeight: 'bold',
-  },
-  'variable': {
-    color: '#a78bfa', // Light Purple
-  },
-  'bold': {
-    fontWeight: 'bold',
-  },
-  'italic': {
-    fontStyle: 'italic',
-  },
-  'operator': {
-    color: '#9ca3af',
-  },
-  'script': {
-    color: '#e3e8f0',
-  },
-  'parameter': {
-    color: '#fbbf24', // Yellow
-  },
-  'method': {
-    color: '#818cf8', // Indigo
-  },
-  'field': {
-    color: '#f59e0b', // Amber/Orange
-  },
-  'annotation': {
-    color: '#6b7280',
-  },
-  'type': {
-    color: '#a78bfa', // Light Purple
-  },
-  'module': {
-    color: '#8b5cf6', // Violet
-  },
-}; 
+
+const baseTheme = {
+  textShadow: 'none',
+  fontFamily: 'var(--font-mono)',
+  fontSize: '0.875em',
+  textAlign: 'left' as const,
+  whiteSpace: 'pre' as const,
+  wordSpacing: 'normal',
+  wordBreak: 'normal' as const,
+  wordWrap: 'normal' as const,
+  lineHeight: '1.5',
+  MozTabSize: '4',
+  OTabSize: '4',
+  tabSize: '4',
+  WebkitHyphens: 'none' as const,
+  MozHyphens: 'none' as const,
+  msHyphens: 'none' as const,
+  hyphens: 'none' as const,
+};
+
+const lightColors = {
+  base: '#1f2937',
+  comment: '#9ca3af',
+  punctuation: '#6b7280',
+  property: '#f59e0b', // Amber/Orange
+  tag: '#8b5cf6', // Violet
+  boolean: '#f59e0b', // Amber/Orange
+  number: '#f59e0b', // Amber/Orange
+  constant: '#f59e0b', // Amber/Orange
+  symbol: '#f59e0b', // Amber/Orange
+  deleted: '#ef4444',
+  selector: '#a78bfa', // Light Purple
+  string: '#10b981', // Emerald Green
+  builtin: '#8b5cf6', // Violet
+  inserted: '#10b981', // Emerald Green
+  entity: '#a78bfa', // Light Purple
+  atrule: '#c084fc', // Light Violet
+  keyword: '#c084fc', // Light Violet
+  function: '#818cf8', // Indigo
+  className: '#f59e0b', // Amber/Orange
+  regex: '#06b6d4', // Cyan
+  important: '#f59e0b', // Amber/Orange
+  variable: '#a78bfa', // Light Purple
+  parameter: '#fbbf24', // Yellow
+  method: '#818cf8', // Indigo
+  field: '#f59e0b', // Amber/Orange
+  annotation: '#9ca3af',
+  type: '#a78bfa', // Light Purple
+  module: '#8b5cf6', // Violet
+  inlineCodeBg: 'rgba(139, 92, 246, 0.15)',
+};
+
+const darkColors = {
+  base: '#e3e8f0',
+  comment: '#6b7280',
+  punctuation: '#9ca3af',
+  property: '#f59e0b', // Amber/Orange
+  tag: '#8b5cf6', // Violet
+  boolean: '#f59e0b', // Amber/Orange
+  number: '#f59e0b', // Amber/Orange
+  constant: '#f59e0b', // Amber/Orange
+  symbol: '#f59e0b', // Amber/Orange
+  deleted: '#ef4444',
+  selector: '#a78bfa', // Light Purple
+  string: '#10b981', // Emerald Green
+  builtin: '#8b5cf6', // Violet
+  inserted: '#10b981', // Emerald Green
+  entity: '#a78bfa', // Light Purple
+  atrule: '#c084fc', // Light Violet
+  keyword: '#c084fc', // Light Violet
+  function: '#818cf8', // Indigo
+  className: '#f59e0b', // Amber/Orange
+  regex: '#06b6d4', // Cyan
+  important: '#f59e0b', // Amber/Orange
+  variable: '#a78bfa', // Light Purple
+  parameter: '#fbbf24', // Yellow
+  method: '#818cf8', // Indigo
+  field: '#f59e0b', // Amber/Orange
+  annotation: '#6b7280',
+  type: '#a78bfa', // Light Purple
+  module: '#8b5cf6', // Violet
+  inlineCodeBg: 'rgba(139, 92, 246, 0.1)',
+};
+
+function createTheme(colors: typeof lightColors) {
+  return {
+    'code[class*="language-"]': {
+      color: colors.base,
+      background: 'transparent',
+      ...baseTheme,
+    },
+    'pre[class*="language-"]': {
+      color: colors.base,
+      background: 'transparent',
+      ...baseTheme,
+      padding: '1em',
+      margin: '0',
+      overflow: 'auto',
+    },
+    ':not(pre) > code[class*="language-"]': {
+      background: colors.inlineCodeBg,
+      padding: '0.1em 0.3em',
+      borderRadius: '0.3em',
+      whiteSpace: 'normal' as const,
+    },
+    'comment': { color: colors.comment, fontStyle: 'italic' },
+    'prolog': { color: colors.comment },
+    'doctype': { color: colors.comment },
+    'cdata': { color: colors.comment },
+    'punctuation': { color: colors.punctuation },
+    'namespace': { opacity: '0.7' },
+    'property': { color: colors.property },
+    'tag': { color: colors.tag },
+    'boolean': { color: colors.boolean },
+    'number': { color: colors.number },
+    'constant': { color: colors.constant },
+    'symbol': { color: colors.symbol },
+    'deleted': { color: colors.deleted },
+    'selector': { color: colors.selector },
+    'attr-name': { color: colors.selector },
+    'string': { color: colors.string },
+    'char': { color: colors.string },
+    'builtin': { color: colors.builtin },
+    'url': { color: colors.string },
+    'inserted': { color: colors.inserted },
+    'entity': { color: colors.entity, cursor: 'help' },
+    'atrule': { color: colors.atrule },
+    'attr-value': { color: colors.string },
+    'keyword': { color: colors.keyword },
+    'function': { color: colors.function },
+    'class-name': { color: colors.className },
+    'regex': { color: colors.regex },
+    'important': { color: colors.important, fontWeight: 'bold' },
+    'variable': { color: colors.variable },
+    'bold': { fontWeight: 'bold' },
+    'italic': { fontStyle: 'italic' },
+    'operator': { color: colors.punctuation },
+    'script': { color: colors.base },
+    'parameter': { color: colors.parameter },
+    'method': { color: colors.method },
+    'field': { color: colors.field },
+    'annotation': { color: colors.annotation },
+    'type': { color: colors.type },
+    'module': { color: colors.module },
+  };
+}
+
+export const claudeSyntaxThemeLight = createTheme(lightColors);
+export const claudeSyntaxThemeDark = createTheme(darkColors);
+
+// Default export for backward compatibility
+export const claudeSyntaxTheme = claudeSyntaxThemeLight;
+
+// Function to get theme based on current theme mode
+export function getClaudeSyntaxTheme(isDark: boolean) {
+  return isDark ? claudeSyntaxThemeDark : claudeSyntaxThemeLight;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { ThemeProvider } from "./contexts/ThemeContext";
 import "./styles.css";
 import "./assets/shimmer.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,26 +1,54 @@
 @import "tailwindcss";
 
-/* Dark theme configuration */
+/* Light theme configuration */
 @theme {
   /* Colors */
-  --color-background: oklch(0.12 0.01 240);
-  --color-foreground: oklch(0.98 0.01 240);
-  --color-card: oklch(0.14 0.01 240);
-  --color-card-foreground: oklch(0.98 0.01 240);
-  --color-popover: oklch(0.12 0.01 240);
-  --color-popover-foreground: oklch(0.98 0.01 240);
-  --color-primary: oklch(0.98 0.01 240);
-  --color-primary-foreground: oklch(0.17 0.01 240);
-  --color-secondary: oklch(0.16 0.01 240);
-  --color-secondary-foreground: oklch(0.98 0.01 240);
-  --color-muted: oklch(0.16 0.01 240);
-  --color-muted-foreground: oklch(0.68 0.01 240);
-  --color-accent: oklch(0.16 0.01 240);
-  --color-accent-foreground: oklch(0.98 0.01 240);
+  --color-background: oklch(0.98 0.01 240);
+  --color-foreground: oklch(0.12 0.01 240);
+  --color-card: oklch(0.96 0.01 240);
+  --color-card-foreground: oklch(0.12 0.01 240);
+  --color-popover: oklch(0.98 0.01 240);
+  --color-popover-foreground: oklch(0.12 0.01 240);
+  --color-primary: oklch(0.12 0.01 240);
+  --color-primary-foreground: oklch(0.98 0.01 240);
+  --color-secondary: oklch(0.94 0.01 240);
+  --color-secondary-foreground: oklch(0.12 0.01 240);
+  --color-muted: oklch(0.94 0.01 240);
+  --color-muted-foreground: oklch(0.45 0.01 240);
+  --color-accent: oklch(0.94 0.01 240);
+  --color-accent-foreground: oklch(0.12 0.01 240);
   --color-destructive: oklch(0.6 0.2 25);
   --color-destructive-foreground: oklch(0.98 0.01 240);
-  --color-border: oklch(0.16 0.01 240);
-  --color-input: oklch(0.16 0.01 240);
+  --color-border: oklch(0.88 0.01 240);
+  --color-input: oklch(0.88 0.01 240);
+  --color-ring: oklch(0.52 0.015 240);
+  
+  /* Additional colors for status messages */
+  --color-green-500: oklch(0.72 0.20 142);
+  --color-green-600: oklch(0.64 0.22 142);
+}
+
+/* Dark theme overrides */
+.dark {
+  /* Colors */
+  --color-background: oklch(0.18 0.01 240);
+  --color-foreground: oklch(0.92 0.01 240);
+  --color-card: oklch(0.22 0.01 240);
+  --color-card-foreground: oklch(0.92 0.01 240);
+  --color-popover: oklch(0.18 0.01 240);
+  --color-popover-foreground: oklch(0.92 0.01 240);
+  --color-primary: oklch(0.92 0.01 240);
+  --color-primary-foreground: oklch(0.22 0.01 240);
+  --color-secondary: oklch(0.24 0.01 240);
+  --color-secondary-foreground: oklch(0.92 0.01 240);
+  --color-muted: oklch(0.24 0.01 240);
+  --color-muted-foreground: oklch(0.65 0.01 240);
+  --color-accent: oklch(0.24 0.01 240);
+  --color-accent-foreground: oklch(0.92 0.01 240);
+  --color-destructive: oklch(0.6 0.2 25);
+  --color-destructive-foreground: oklch(0.98 0.01 240);
+  --color-border: oklch(0.26 0.01 240);
+  --color-input: oklch(0.26 0.01 240);
   --color-ring: oklch(0.52 0.015 240);
   
   /* Additional colors for status messages */
@@ -157,11 +185,23 @@ button:focus-visible,
   }
 }
 
+/* Markdown Editor Light Mode Styles */
+[data-color-mode="light"] {
+  --color-border-default: rgb(208, 215, 222);
+  --color-canvas-default: rgb(255, 255, 255);
+  --color-canvas-subtle: rgb(246, 248, 250);
+  --color-fg-default: rgb(31, 35, 40);
+  --color-fg-muted: rgb(101, 109, 118);
+  --color-fg-subtle: rgb(144, 157, 171);
+  --color-accent-fg: rgb(9, 105, 218);
+  --color-danger-fg: rgb(207, 34, 46);
+}
+
 /* Markdown Editor Dark Mode Styles */
 [data-color-mode="dark"] {
-  --color-border-default: rgb(48, 54, 61);
-  --color-canvas-default: rgb(13, 17, 23);
-  --color-canvas-subtle: rgb(22, 27, 34);
+  --color-border-default: rgb(68, 76, 86);
+  --color-canvas-default: rgb(22, 27, 34);
+  --color-canvas-subtle: rgb(32, 39, 48);
   --color-fg-default: rgb(201, 209, 217);
   --color-fg-muted: rgb(139, 148, 158);
   --color-fg-subtle: rgb(110, 118, 129);
@@ -402,8 +442,8 @@ button:focus-visible,
   background-color: var(--color-muted);
 }
 
-.prose.dark\:prose-invert pre {
-  background-color: rgb(13, 17, 23);
+.prose pre {
+  background-color: var(--color-card);
   border: 1px solid var(--color-border);
 }
 


### PR DESCRIPTION
- Add theme context provider for global theme state management
- Implement theme selector component with moon/sun icons
- Add dynamic theme switching with localStorage persistence
- Update CSS to support both light and dark color schemes
- Enhance syntax highlighting with theme-aware color palettes
- Integrate theme selector into top navigation bar
- Update all markdown editors to use dynamic theme modes
- Improve dark mode contrast for better accessibility

Features:
- Toggle between light and dark themes
- Persistent theme preference storage
- System preference detection on first visit
- Theme-aware syntax highlighting
- Better contrast in dark mode vs original low-contrast design