### PR TITLE
fix: resolve Windows build issues

### DIFF
--- a/scripts/fetch-and-build.js
+++ b/scripts/fetch-and-build.js
@@ -19,7 +19,7 @@
  */
 
 import { spawn } from 'child_process';
-import { mkdir, rm, readdir, copyFile, access } from 'fs/promises';
+import { mkdir, rm, readdir, copyFile, access, cp } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 
@@ -207,8 +207,8 @@ async function copyRequiredFiles(packageDir) {
         await rm(destPath, { recursive: true, force: true });
       }
       
-      // Copy directory recursively using cp command
-      await runCommand('cp', ['-r', srcPath, destPath]);
+      // Copy directory recursively using Node.js built-in function
+      await cp(srcPath, destPath, { recursive: true });
     } else {
       console.warn(`Warning: ${dir}/ directory not found in package`);
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,6 +56,7 @@
       "icons/128x128.png",
       "icons/128x128@2x.png",
       "icons/icon.icns",
+      "icons/icon.ico",
       "icons/icon.png"
     ],
     "externalBin": [


### PR DESCRIPTION
- Replace Unix-specific cp -r command with cross-platform Node.js cp() function
- Add icon.ico to Tauri bundle configuration to fix Windows bundling

These changes enable successful builds on Windows systems