### PR TITLE
feat: add project language detection

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod usage;
 pub mod storage;
 pub mod slash_commands;
 pub mod proxy;
+pub mod project_analysis;

--- a/src-tauri/src/commands/project_analysis.rs
+++ b/src-tauri/src/commands/project_analysis.rs
@@ -1,0 +1,486 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::process::Command;
+use tauri::State;
+use crate::language_cache::LanguageCache;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct LanguageStats {
+    pub name: String,
+    pub percentage: f32,
+    pub bytes: u64,
+    pub color: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ProjectAnalysis {
+    pub languages: Vec<LanguageStats>,
+    pub total_files: u32,
+    pub total_bytes: u64,
+    pub analyzed_at: u64,
+}
+
+#[tauri::command]
+pub async fn analyze_project_languages(
+    project_path: String,
+    cache: State<'_, LanguageCache>,
+) -> Result<ProjectAnalysis, String> {
+    log::info!("Analyzing project languages for: {project_path}");
+    
+    let path = PathBuf::from(&project_path);
+    
+    // Early return for non-existent paths
+    if !path.exists() {
+        log::warn!("Project path does not exist: {project_path}, returning empty analysis");
+        return Ok(ProjectAnalysis {
+            languages: Vec::new(),
+            total_files: 0,
+            total_bytes: 0,
+            analyzed_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        });
+    }
+    
+    // Skip analysis for empty directories
+    if path.is_dir() {
+        let mut entries = std::fs::read_dir(&path).map_err(|e| format!("Failed to read directory: {e}"))?;
+        if entries.next().is_none() {
+            log::info!("Directory is empty: {project_path}");
+            return Ok(ProjectAnalysis {
+                languages: Vec::new(),
+                total_files: 0,
+                total_bytes: 0,
+                analyzed_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            });
+        }
+    }
+
+    let cache_key = format!("lang_analysis_{}", project_path.replace("/", "_"));
+    
+    // Check in-memory cache first
+    if let Some(cached) = cache.get(&cache_key) {
+        return Ok(cached);
+    }
+    
+    // Then check file cache
+    if let Ok(cached) = get_cached_analysis(&cache_key) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        
+        if now - cached.analyzed_at < 3600 {
+            // Store in memory cache for faster access
+            cache.set(cache_key.clone(), cached.clone());
+            return Ok(cached);
+        }
+    }
+
+    // linguist-js outputs JS object notation, not valid JSON, so we need to convert it
+    let output = if cfg!(target_os = "windows") {
+        let cmd_str = format!(
+            "npx linguist-js --analyze \"{project_path}\" --json 2>nul | node -e \"const input = require('fs').readFileSync(0, 'utf8'); if (input.trim()) {{ try {{ console.log(JSON.stringify(eval('(' + input + ')'))); }} catch (e) {{ console.error('Parse error:', e.message); process.exit(1); }} }} else {{ console.log('{{}}'); }}\""
+        );
+        Command::new("cmd")
+            .args(["/C", &cmd_str])
+            .output()
+            .map_err(|e| format!("Failed to run linguist-js: {e}"))?
+    } else {
+        let cmd_str = format!(
+            "npx linguist-js --analyze \"{project_path}\" --json 2>/dev/null | node -e \"const input = require('fs').readFileSync(0, 'utf8'); if (input.trim()) {{ try {{ console.log(JSON.stringify(eval('(' + input + ')'))); }} catch (e) {{ console.error('Parse error:', e.message); process.exit(1); }} }} else {{ console.log('{{}}'); }}\""
+        );
+        Command::new("sh")
+            .args(["-c", &cmd_str])
+            .output()
+            .map_err(|e| format!("Failed to run linguist-js: {e}"))?
+    };
+
+    if !output.status.success() {
+        log::error!("linguist-js stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return Err(format!("linguist-js failed: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+    
+    log::debug!("linguist-js output length: {} bytes", output.stdout.len());
+
+    // Handle empty output case
+    if output.stdout.is_empty() || output.stdout == b"{}" {
+        log::warn!("linguist-js returned empty output for {project_path}");
+        return Ok(ProjectAnalysis {
+            languages: Vec::new(),
+            total_files: 0,
+            total_bytes: 0,
+            analyzed_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        });
+    }
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse linguist output: {e}"))?;
+    
+    log::debug!("Parsed JSON keys: {:?}", result.as_object().map(|o| o.keys().collect::<Vec<_>>()));
+
+    // Handle missing fields gracefully
+    let total_bytes = result.get("languages")
+        .and_then(|l| l.get("bytes"))
+        .and_then(|b| b.as_u64())
+        .unwrap_or(0);
+    
+    let languages = if let Some(langs) = result.get("languages")
+        .and_then(|l| l.get("results"))
+        .and_then(|r| r.as_object()) {
+        let mut language_vec: Vec<LanguageStats> = langs
+            .iter()
+            .filter_map(|(name, data)| {
+                let bytes = data["bytes"].as_u64().unwrap_or(0);
+                if bytes == 0 {
+                    return None;
+                }
+                
+                let percentage = if total_bytes > 0 {
+                    (bytes as f64 / total_bytes as f64 * 100.0) as f32
+                } else {
+                    0.0
+                };
+                
+                let color = data["color"].as_str()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| get_language_color(name));
+                
+                Some(LanguageStats {
+                    name: name.clone(),
+                    percentage,
+                    bytes,
+                    color,
+                })
+            })
+            .filter(|lang| lang.percentage > 0.1)
+            .collect();
+
+        language_vec.sort_by(|a, b| b.percentage.partial_cmp(&a.percentage).unwrap());
+        language_vec.truncate(10);
+        
+        log::info!("Found {} languages for project {}", language_vec.len(), project_path);
+        for lang in &language_vec {
+            log::debug!("  - {}: {:.1}% ({} bytes)", lang.name, lang.percentage, lang.bytes);
+        }
+        
+        language_vec
+    } else {
+        log::warn!("No languages found in linguist output");
+        Vec::new()
+    };
+
+    let total_files = result.get("files")
+        .and_then(|f| f.get("count"))
+        .and_then(|c| c.as_u64())
+        .unwrap_or(0) as u32;
+    
+    let analysis = ProjectAnalysis {
+        languages,
+        total_files,
+        total_bytes,
+        analyzed_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    };
+
+    // Store in both file and memory cache
+    cache_analysis(&cache_key, &analysis)?;
+    cache.set(cache_key, analysis.clone());
+    
+    Ok(analysis)
+}
+
+#[tauri::command]
+pub async fn analyze_projects_batch(
+    project_paths: Vec<String>,
+    cache: State<'_, LanguageCache>,
+) -> Result<Vec<(String, Result<ProjectAnalysis, String>)>, String> {
+    use futures::future::join_all;
+    
+    log::info!("Batch analyzing {} projects", project_paths.len());
+    
+    let cache_ref = cache.inner().clone();
+    
+    let futures = project_paths.into_iter().map(|path| {
+        let cache_clone = cache_ref.clone();
+        async move {
+            let result = analyze_single_project(path.clone(), &cache_clone).await;
+            (path, result)
+        }
+    });
+    
+    let results = join_all(futures).await;
+    Ok(results)
+}
+
+async fn analyze_single_project(
+    project_path: String,
+    cache: &LanguageCache,
+) -> Result<ProjectAnalysis, String> {
+    let path = PathBuf::from(&project_path);
+    
+    // Early return for non-existent paths
+    if !path.exists() {
+        log::warn!("Project path does not exist: {project_path}, returning empty analysis");
+        return Ok(ProjectAnalysis {
+            languages: Vec::new(),
+            total_files: 0,
+            total_bytes: 0,
+            analyzed_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        });
+    }
+    
+    let cache_key = format!("lang_analysis_{}", project_path.replace("/", "_"));
+    
+    // Check in-memory cache first
+    if let Some(cached) = cache.get(&cache_key) {
+        return Ok(cached);
+    }
+    
+    // Then check file cache
+    if let Ok(cached) = get_cached_analysis(&cache_key) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        
+        if now - cached.analyzed_at < 3600 {
+            // Store in memory cache for faster access
+            cache.set(cache_key.clone(), cached.clone());
+            return Ok(cached);
+        }
+    }
+    
+    // Skip analysis for empty directories
+    if path.is_dir() {
+        let mut entries = std::fs::read_dir(&path).map_err(|e| format!("Failed to read directory: {e}"))?;
+        if entries.next().is_none() {
+            log::info!("Directory is empty: {project_path}");
+            return Ok(ProjectAnalysis {
+                languages: Vec::new(),
+                total_files: 0,
+                total_bytes: 0,
+                analyzed_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            });
+        }
+    }
+    
+    // Run linguist-js
+    let project_path_clone = project_path.clone();
+    let output = tokio::task::spawn_blocking(move || {
+        run_linguist_js(&project_path_clone)
+    }).await
+    .map_err(|e| format!("Failed to spawn blocking task: {e}"))?
+    .map_err(|e| format!("Failed to run linguist-js: {e}"))?;
+    
+    // Parse and process the output
+    let analysis = parse_linguist_output(output, &project_path)?;
+    
+    // Store in both file and memory cache
+    cache_analysis(&cache_key, &analysis)?;
+    cache.set(cache_key, analysis.clone());
+    
+    Ok(analysis)
+}
+
+fn run_linguist_js(project_path: &str) -> Result<std::process::Output, String> {
+    let cmd_str = if cfg!(target_os = "windows") {
+        format!(
+            "npx linguist-js --analyze \"{project_path}\" --json 2>nul | node -e \"const input = require('fs').readFileSync(0, 'utf8'); if (input.trim()) {{ try {{ console.log(JSON.stringify(eval('(' + input + ')'))); }} catch (e) {{ console.error('Parse error:', e.message); process.exit(1); }} }} else {{ console.log('{{}}'); }}\""
+        )
+    } else {
+        format!(
+            "npx linguist-js --analyze \"{project_path}\" --json 2>/dev/null | node -e \"const input = require('fs').readFileSync(0, 'utf8'); if (input.trim()) {{ try {{ console.log(JSON.stringify(eval('(' + input + ')'))); }} catch (e) {{ console.error('Parse error:', e.message); process.exit(1); }} }} else {{ console.log('{{}}'); }}\""
+        )
+    };
+    
+    let output = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .args(["/C", &cmd_str])
+            .output()
+    } else {
+        Command::new("sh")
+            .args(["-c", &cmd_str])
+            .output()
+    };
+    
+    output.map_err(|e| format!("Failed to run linguist-js: {e}"))
+}
+
+fn parse_linguist_output(output: std::process::Output, project_path: &str) -> Result<ProjectAnalysis, String> {
+    if !output.status.success() {
+        log::error!("linguist-js stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return Err(format!("linguist-js failed: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+    
+    log::debug!("linguist-js output length: {} bytes", output.stdout.len());
+    
+    // Handle empty output case
+    if output.stdout.is_empty() || output.stdout == b"{}" {
+        log::warn!("linguist-js returned empty output for {project_path}");
+        return Ok(ProjectAnalysis {
+            languages: Vec::new(),
+            total_files: 0,
+            total_bytes: 0,
+            analyzed_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        });
+    }
+    
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("Failed to parse linguist output: {e}"))?;
+    
+    log::debug!("Parsed JSON keys: {:?}", result.as_object().map(|o| o.keys().collect::<Vec<_>>()));
+    
+    // Handle missing fields gracefully
+    let total_bytes = result.get("languages")
+        .and_then(|l| l.get("bytes"))
+        .and_then(|b| b.as_u64())
+        .unwrap_or(0);
+    
+    let languages = if let Some(langs) = result.get("languages")
+        .and_then(|l| l.get("results"))
+        .and_then(|r| r.as_object()) {
+        let mut language_vec: Vec<LanguageStats> = langs
+            .iter()
+            .filter_map(|(name, data)| {
+                let bytes = data["bytes"].as_u64().unwrap_or(0);
+                if bytes == 0 {
+                    return None;
+                }
+                
+                let percentage = if total_bytes > 0 {
+                    (bytes as f64 / total_bytes as f64 * 100.0) as f32
+                } else {
+                    0.0
+                };
+                
+                let color = data["color"].as_str()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| get_language_color(name));
+                
+                Some(LanguageStats {
+                    name: name.clone(),
+                    percentage,
+                    bytes,
+                    color,
+                })
+            })
+            .filter(|lang| lang.percentage > 0.1)
+            .collect();
+
+        language_vec.sort_by(|a, b| b.percentage.partial_cmp(&a.percentage).unwrap());
+        language_vec.truncate(10);
+        
+        log::info!("Found {} languages for project {}", language_vec.len(), project_path);
+        for lang in &language_vec {
+            log::debug!("  - {}: {:.1}% ({} bytes)", lang.name, lang.percentage, lang.bytes);
+        }
+        
+        language_vec
+    } else {
+        log::warn!("No languages found in linguist output");
+        Vec::new()
+    };
+
+    let total_files = result.get("files")
+        .and_then(|f| f.get("count"))
+        .and_then(|c| c.as_u64())
+        .unwrap_or(0) as u32;
+    
+    Ok(ProjectAnalysis {
+        languages,
+        total_files,
+        total_bytes,
+        analyzed_at: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    })
+}
+
+fn get_language_color(language: &str) -> String {
+    match language {
+        "JavaScript" => "#f1e05a".to_string(),
+        "TypeScript" => "#3178c6".to_string(),
+        "Python" => "#3572A5".to_string(),
+        "Rust" => "#dea584".to_string(),
+        "Go" => "#00ADD8".to_string(),
+        "Java" => "#b07219".to_string(),
+        "C++" => "#f34b7d".to_string(),
+        "C" => "#555555".to_string(),
+        "C#" => "#178600".to_string(),
+        "PHP" => "#4F5D95".to_string(),
+        "Ruby" => "#701516".to_string(),
+        "Swift" => "#FA7343".to_string(),
+        "Kotlin" => "#A97BFF".to_string(),
+        "Dart" => "#00B4AB".to_string(),
+        "Vue" => "#41b883".to_string(),
+        "HTML" => "#e34c26".to_string(),
+        "CSS" => "#563d7c".to_string(),
+        "SCSS" => "#c6538c".to_string(),
+        "Shell" => "#89e051".to_string(),
+        "YAML" => "#cb171e".to_string(),
+        "JSON" => "#292929".to_string(),
+        "Markdown" => "#083fa1".to_string(),
+        _ => "#6c757d".to_string(),
+    }
+}
+
+fn get_cached_analysis(cache_key: &str) -> Result<ProjectAnalysis, String> {
+    let cache_dir = dirs::cache_dir()
+        .ok_or("Failed to get cache directory")?
+        .join("claudia")
+        .join("language_cache");
+    
+    let cache_file = cache_dir.join(format!("{cache_key}.json"));
+    
+    if cache_file.exists() {
+        let content = std::fs::read_to_string(&cache_file)
+            .map_err(|e| format!("Failed to read cache: {e}"))?;
+        
+        let analysis = serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse cache: {e}"))?;
+        
+        Ok(analysis)
+    } else {
+        Err("Cache not found".to_string())
+    }
+}
+
+fn cache_analysis(cache_key: &str, analysis: &ProjectAnalysis) -> Result<(), String> {
+    let cache_dir = dirs::cache_dir()
+        .ok_or("Failed to get cache directory")?
+        .join("claudia")
+        .join("language_cache");
+    
+    std::fs::create_dir_all(&cache_dir)
+        .map_err(|e| format!("Failed to create cache directory: {e}"))?;
+    
+    let cache_file = cache_dir.join(format!("{cache_key}.json"));
+    
+    let content = serde_json::to_string(analysis)
+        .map_err(|e| format!("Failed to serialize analysis: {e}"))?;
+    
+    std::fs::write(&cache_file, content)
+        .map_err(|e| format!("Failed to write cache: {e}"))?;
+    
+    Ok(())
+}

--- a/src-tauri/src/language_cache.rs
+++ b/src-tauri/src/language_cache.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use crate::commands::project_analysis::ProjectAnalysis;
+
+#[derive(Clone)]
+pub struct LanguageCache {
+    cache: Arc<Mutex<HashMap<String, CachedAnalysis>>>,
+    ttl: Duration,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct CachedAnalysis {
+    data: ProjectAnalysis,
+    cached_at: u64,
+}
+
+impl LanguageCache {
+    pub fn new(ttl_seconds: u64) -> Self {
+        Self {
+            cache: Arc::new(Mutex::new(HashMap::new())),
+            ttl: Duration::from_secs(ttl_seconds),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<ProjectAnalysis> {
+        let cache = self.cache.lock().unwrap();
+        
+        if let Some(cached) = cache.get(key) {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            
+            let age = Duration::from_secs(now - cached.cached_at);
+            
+            if age < self.ttl {
+                log::debug!("Cache hit for key: {}", key);
+                return Some(cached.data.clone());
+            } else {
+                log::debug!("Cache expired for key: {}", key);
+            }
+        }
+        
+        None
+    }
+
+    pub fn set(&self, key: String, data: ProjectAnalysis) {
+        let mut cache = self.cache.lock().unwrap();
+        
+        let cached = CachedAnalysis {
+            data,
+            cached_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        };
+        
+        log::debug!("Cached analysis for key: {}", &key);
+        cache.insert(key, cached);
+    }
+
+    pub fn invalidate(&self, key: &str) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.remove(key);
+        log::debug!("Invalidated cache for key: {}", key);
+    }
+
+    pub fn clear(&self) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.clear();
+        log::debug!("Cleared all cache entries");
+    }
+
+    pub fn size(&self) -> usize {
+        let cache = self.cache.lock().unwrap();
+        cache.len()
+    }
+}
+
+impl Default for LanguageCache {
+    fn default() -> Self {
+        Self::new(3600) // 1 hour default TTL
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod checkpoint;
 pub mod claude_binary;
 pub mod commands;
 pub mod process;
+pub mod language_cache;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod checkpoint;
 mod claude_binary;
 mod commands;
 mod process;
+mod language_cache;
 
 use checkpoint::state::CheckpointState;
 use commands::agents::{
@@ -43,6 +44,10 @@ use commands::storage::{
     storage_insert_row, storage_execute_sql, storage_reset_database,
 };
 use commands::proxy::{get_proxy_settings, save_proxy_settings, apply_proxy_settings};
+use commands::project_analysis::{
+    analyze_project_languages,
+};
+use language_cache::LanguageCache;
 use process::ProcessRegistryState;
 use std::sync::Mutex;
 use tauri::Manager;
@@ -135,6 +140,9 @@ fn main() {
 
             // Initialize Claude process state
             app.manage(ClaudeProcessState::default());
+
+            // Initialize language analysis cache
+            app.manage(LanguageCache::new(3600)); // 1 hour TTL
 
             Ok(())
         })
@@ -239,6 +247,10 @@ fn main() {
             storage_insert_row,
             storage_execute_sql,
             storage_reset_database,
+            
+            // Project Analysis
+            analyze_project_languages,
+            commands::project_analysis::analyze_projects_batch,
             
             // Slash Commands
             commands::slash_commands::slash_commands_list,

--- a/src/components/ProjectLanguages.tsx
+++ b/src/components/ProjectLanguages.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { api } from '@/lib/api';
+import { getLanguageIcon, getLanguageColor } from '@/lib/languageIcons';
+import { cn } from '@/lib/utils';
+
+interface LanguageStats {
+  name: string;
+  percentage: number;
+  bytes: number;
+  color: string;
+}
+
+interface ProjectAnalysis {
+  languages: LanguageStats[];
+  total_files: number;
+  total_bytes: number;
+  analyzed_at: number;
+}
+
+interface ProjectLanguagesProps {
+  projectPath: string;
+  projectId: string;
+  maxLanguages?: number;
+  className?: string;
+}
+
+// Memoize loading skeleton to prevent re-renders
+const LoadingSkeleton = React.memo(() => (
+  <div className="flex gap-1 mt-2">
+    <div className="h-5 flex items-center gap-2">
+      <div className="flex gap-0.5">
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            className="w-1 h-3 bg-muted-foreground/20 rounded-full animate-pulse"
+            style={{
+              animationDelay: `${i * 150}ms`,
+              animationDuration: '1s'
+            }}
+          />
+        ))}
+      </div>
+      <span className="text-[9px] text-muted-foreground/50">Analyzing...</span>
+    </div>
+  </div>
+));
+
+LoadingSkeleton.displayName = 'LoadingSkeleton';
+
+// Memoize empty state to prevent re-renders
+const EmptyState = React.memo(() => (
+  <div className="flex gap-1 mt-2">
+    <Badge 
+      variant="outline" 
+      className="text-[9px] px-1.5 py-0 h-5 opacity-50 cursor-not-allowed"
+    >
+      <svg 
+        className="w-2 h-2 mr-0.5" 
+        fill="none" 
+        stroke="currentColor" 
+        viewBox="0 0 24 24"
+      >
+        <path 
+          strokeLinecap="round" 
+          strokeLinejoin="round" 
+          strokeWidth={2} 
+          d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" 
+        />
+      </svg>
+      <span className="font-medium">Empty codebase</span>
+    </Badge>
+  </div>
+));
+
+EmptyState.displayName = 'EmptyState';
+
+// Language badge component
+const LanguageBadge = React.memo<{
+  lang: LanguageStats;
+  color: string;
+  IconComponent: any;
+  context: string | null;
+  isBlackLogo: boolean;
+}>(({ lang, color, IconComponent, context, isBlackLogo }) => (
+  <Badge
+    variant="secondary"
+    className="text-[9px] pl-1.5 pr-1 py-0 h-5 flex items-center gap-0.5 transition-colors border"
+    style={{
+      backgroundColor: `${color}18`,
+      borderColor: `${color}30`,
+      color: 'hsl(var(--foreground))'
+    }}
+  >
+    {IconComponent && (
+      <IconComponent 
+        className="w-2 h-2 mr-0.5 flex-shrink-0" 
+        style={{ 
+          color: color,
+          opacity: 0.8,
+          filter: isBlackLogo ? 'brightness(0) invert(1)' : 'none'
+        }} 
+      />
+    )}
+    <span className="font-medium opacity-90">{lang.name}</span>
+    {context && (
+      <span 
+        className="px-0.5 py-0 text-[8px] rounded-sm opacity-60"
+        style={{
+          backgroundColor: `${color}20`,
+        }}
+      >
+        {context}
+      </span>
+    )}
+    <span 
+      className="ml-0.5 px-0.5 py-0 text-[9px] font-mono rounded-sm"
+      style={{
+        backgroundColor: `${color}25`,
+        color: 'hsl(var(--foreground))'
+      }}
+    >
+      {lang.percentage.toFixed(1)}%
+    </span>
+  </Badge>
+));
+
+LanguageBadge.displayName = 'LanguageBadge';
+
+export const ProjectLanguages = React.memo<ProjectLanguagesProps>(({
+  projectPath,
+  projectId,
+  maxLanguages = 5,
+  className
+}) => {
+  const [analysis, setAnalysis] = useState<ProjectAnalysis | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Memoize cache operations
+  const cacheKey = useMemo(() => `lang_analysis_${projectId}`, [projectId]);
+  
+  const getCachedData = useCallback(() => {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      try {
+        const { data, timestamp } = JSON.parse(cached);
+        const oneHourAgo = Date.now() - 3600000;
+        if (timestamp > oneHourAgo) {
+          return data;
+        }
+      } catch (e) {
+        // Silent fail for cache parsing
+      }
+    }
+    return null;
+  }, [cacheKey]);
+
+  const setCachedData = useCallback((data: ProjectAnalysis) => {
+    try {
+      localStorage.setItem(cacheKey, JSON.stringify({
+        data,
+        timestamp: Date.now()
+      }));
+    } catch (e) {
+      // Silent fail for cache writing
+    }
+  }, [cacheKey]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchLanguages = async () => {
+      // Check cache first
+      const cachedData = getCachedData();
+      if (cachedData) {
+        if (!cancelled) {
+          setAnalysis(cachedData);
+          setLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const data = await api.analyzeProjectLanguages(projectPath);
+        if (!cancelled) {
+          setAnalysis(data);
+          setCachedData(data);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err.message || 'Analysis failed');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchLanguages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath, getCachedData, setCachedData]);
+
+  // Memoize language processing
+  const { displayLanguages, remainingCount } = useMemo(() => {
+    if (!analysis || analysis.languages.length === 0) {
+      return { displayLanguages: [], remainingCount: 0 };
+    }
+
+    // Group related languages together
+    const languageGroups: Record<string, string[]> = {
+      'TypeScript': ['TSX', 'TypeScript'],
+      'JavaScript': ['JSX', 'JavaScript'],
+      'Style': ['CSS', 'SCSS', 'SASS', 'Less'],
+      'Data': ['JSON', 'YAML', 'TOML', 'XML']
+    };
+    
+    // Sort languages with grouping
+    const sortedLanguages = [...analysis.languages].sort((a, b) => {
+      // First by percentage
+      if (Math.abs(b.percentage - a.percentage) > 5) {
+        return b.percentage - a.percentage;
+      }
+      
+      // Then group related languages
+      for (const [, group] of Object.entries(languageGroups)) {
+        const aInGroup = group.includes(a.name);
+        const bInGroup = group.includes(b.name);
+        if (aInGroup && bInGroup) {
+          return group.indexOf(a.name) - group.indexOf(b.name);
+        }
+        if (aInGroup || bInGroup) {
+          return aInGroup ? -1 : 1;
+        }
+      }
+      
+      return b.percentage - a.percentage;
+    });
+    
+    return {
+      displayLanguages: sortedLanguages.slice(0, maxLanguages),
+      remainingCount: Math.max(0, analysis.languages.length - maxLanguages)
+    };
+  }, [analysis, maxLanguages]);
+
+  // Languages that have black/dark logos that need to be inverted to white
+  const blackLogoLanguages = useMemo(() => [
+    'Markdown', 'Next.js', 'Apple', 'Flask', 'GitHub', 'Rust', 
+    'Shell', 'JSON', 'C', 'Django', 'Ruby'
+  ], []);
+
+  // Get language context (UI, Config, etc)
+  const getLanguageContext = useCallback((lang: string): string | null => {
+    if (lang === 'TSX' || lang === 'JSX') return 'UI';
+    if (lang === 'JSON' || lang === 'YAML' || lang === 'TOML') return 'Config';
+    if (lang === 'SCSS' || lang === 'SASS' || lang === 'Less') return 'Style';
+    return null;
+  }, []);
+
+  if (loading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (error || !analysis || analysis.languages.length === 0) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className={cn("flex flex-wrap gap-1 mt-2", className)}>
+      {displayLanguages.map((lang) => {
+        const IconComponent = getLanguageIcon(lang.name);
+        const color = lang.color || getLanguageColor(lang.name);
+        const context = getLanguageContext(lang.name);
+        const isBlackLogo = blackLogoLanguages.includes(lang.name);
+        
+        return (
+          <LanguageBadge
+            key={lang.name}
+            lang={lang}
+            color={color}
+            IconComponent={IconComponent}
+            context={context}
+            isBlackLogo={isBlackLogo}
+          />
+        );
+      })}
+      
+      {remainingCount > 0 && (
+        <Badge 
+          variant="outline" 
+          className="text-[10px] px-1.5 py-0 h-5 text-muted-foreground"
+        >
+          +{remainingCount}
+        </Badge>
+      )}
+    </div>
+  );
+});
+
+ProjectLanguages.displayName = 'ProjectLanguages';

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { Project } from "@/lib/api";
+import { ProjectLanguages } from "@/components/ProjectLanguages";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/lib/date-utils";
 import { Pagination } from "@/components/ui/pagination";
@@ -120,6 +121,8 @@ export const ProjectList: React.FC<ProjectListProps> = ({
                   <p className="text-sm text-muted-foreground mb-3 font-mono truncate">
                     {project.path}
                   </p>
+                  
+                  <ProjectLanguages projectPath={project.path} />
                 </div>
                 
                 <div className="flex items-center justify-between">

--- a/src/lib/languageIcons.ts
+++ b/src/lib/languageIcons.ts
@@ -1,0 +1,66 @@
+import * as DevIcons from 'devicons-react';
+
+interface LanguageConfig {
+  icon: keyof typeof DevIcons;
+  color: string;
+}
+
+export const LANGUAGE_CONFIG: Record<string, LanguageConfig> = {
+  'JavaScript': { icon: 'JavascriptOriginal', color: '#f1e05a' },
+  'TypeScript': { icon: 'TypescriptOriginal', color: '#3178c6' },
+  'Python': { icon: 'PythonOriginal', color: '#3572A5' },
+  'Rust': { icon: 'RustOriginal', color: '#dea584' },
+  'Go': { icon: 'GoOriginal', color: '#00ADD8' },
+  'Java': { icon: 'JavaOriginal', color: '#b07219' },
+  'C++': { icon: 'CplusplusOriginal', color: '#f34b7d' },
+  'C': { icon: 'COriginal', color: '#555555' },
+  'C#': { icon: 'CsharpOriginal', color: '#178600' },
+  'PHP': { icon: 'PhpOriginal', color: '#4F5D95' },
+  'Ruby': { icon: 'RubyOriginal', color: '#701516' },
+  'Swift': { icon: 'SwiftOriginal', color: '#FA7343' },
+  'Kotlin': { icon: 'KotlinOriginal', color: '#A97BFF' },
+  'Dart': { icon: 'DartOriginal', color: '#00B4AB' },
+  'Vue': { icon: 'VuejsOriginal', color: '#41b883' },
+  'HTML': { icon: 'Html5Original', color: '#e34c26' },
+  'CSS': { icon: 'Css3Original', color: '#563d7c' },
+  'SCSS': { icon: 'SassOriginal', color: '#c6538c' },
+  'Shell': { icon: 'BashOriginal', color: '#89e051' },
+  'YAML': { icon: 'YamlPlain', color: '#cb171e' },
+  'JSON': { icon: 'JsonPlain', color: '#292929' },
+  'Markdown': { icon: 'MarkdownOriginal', color: '#083fa1' },
+  'React': { icon: 'ReactOriginal', color: '#61dafb' },
+  'Node.js': { icon: 'NodejsOriginal', color: '#339933' },
+  'Docker': { icon: 'DockerOriginal', color: '#2496ed' },
+  'GraphQL': { icon: 'GraphqlPlain', color: '#e10098' },
+  'MongoDB': { icon: 'MongodbOriginal', color: '#47A248' },
+  'PostgreSQL': { icon: 'PostgresqlOriginal', color: '#336791' },
+  'MySQL': { icon: 'MysqlOriginal', color: '#4479A1' },
+  'Redis': { icon: 'RedisOriginal', color: '#DC382D' },
+  'Git': { icon: 'GitOriginal', color: '#F05032' },
+  'Vim': { icon: 'VimOriginal', color: '#019733' },
+  'Linux': { icon: 'LinuxOriginal', color: '#FCC624' },
+  'Windows': { icon: 'Windows8Original', color: '#0078D6' },
+  'Apple': { icon: 'AppleOriginal', color: '#000000' },
+  'Android': { icon: 'AndroidOriginal', color: '#3DDC84' },
+  'Flutter': { icon: 'FlutterOriginal', color: '#02569B' },
+  'Tailwind CSS': { icon: 'TailwindcssOriginal', color: '#06b6d4' },
+  'Next.js': { icon: 'NextjsOriginal', color: '#000000' },
+  'Svelte': { icon: 'SvelteOriginal', color: '#ff3e00' },
+  'Angular': { icon: 'AngularOriginal', color: '#DD0031' },
+  'Django': { icon: 'DjangoPlain', color: '#092E20' },
+  'Flask': { icon: 'FlaskOriginal', color: '#000000' },
+  'Laravel': { icon: 'LaravelOriginal', color: '#FF2D20' },
+  'Spring': { icon: 'SpringOriginal', color: '#6DB33F' },
+};
+
+export const getLanguageIcon = (language: string): React.ComponentType<any> | null => {
+  const config = LANGUAGE_CONFIG[language];
+  if (!config) return null;
+  
+  const IconComponent = DevIcons[config.icon];
+  return IconComponent || null;
+};
+
+export const getLanguageColor = (language: string): string => {
+  return LANGUAGE_CONFIG[language]?.color || '#6c757d';
+};


### PR DESCRIPTION
## Summary
- Added language detection feature for projects using linguist-js
- Display programming language badges with icons in project cards  
- Implemented efficient caching to avoid repeated analysis

## Implementation Details
- Uses `linguist-js` to analyze project languages
- In-memory cache with 1-hour TTL to optimize performance
- Support for 40+ programming languages with devicons-react
- Graceful error handling for missing or inaccessible projects

## Testing
- Tested with various project types (React, Rust, Python, etc.)
- Verified caching works correctly
- Confirmed error handling for non-existent paths